### PR TITLE
🧹 Remove deprecated figure_only argument in pyglotaran-extras plot functions

### DIFF
--- a/4TT/sequential_doas_4TT.ipynb
+++ b/4TT/sequential_doas_4TT.ipynb
@@ -355,9 +355,7 @@
    "source": [
     "from pyglotaran_extras import plot_overview\n",
     "\n",
-    "fig, axes = plot_overview(\n",
-    "    result, linlog=True, linthresh=1, figure_only=False, nr_of_residual_svd_vectors=1\n",
-    ")\n",
+    "fig, axes = plot_overview(result, linlog=True, linthresh=1, nr_of_residual_svd_vectors=1)\n",
     "\n",
     "# Add thin line at zero to SAS and DAS plots\n",
     "for ax in axes[0:2, 1:3].flatten():\n",
@@ -643,7 +641,7 @@
    "source": [
     "from pyglotaran_extras import plot_overview\n",
     "\n",
-    "fig, axes = plot_overview(result_corr, linlog=True, linthresh=1, figure_only=False)\n",
+    "fig, axes = plot_overview(result_corr, linlog=True, linthresh=1)\n",
     "\n",
     "# Add thin line at zero to SAS and DAS plots\n",
     "for ax in axes[0:2, 1:3].flatten():\n",

--- a/dPSI/ex_four_datasets_two_guidance_with_area_irf-with_sum_plot_minimal.ipynb
+++ b/dPSI/ex_four_datasets_two_guidance_with_area_irf-with_sum_plot_minimal.ipynb
@@ -294,13 +294,7 @@
    "source": [
     "from pyglotaran_extras import plot_overview\n",
     "\n",
-    "plot_overview(\n",
-    "    result.data[\"DPSI590tr4\"],\n",
-    "    linlog=True,\n",
-    "    linthresh=150,\n",
-    "    figure_only=False,\n",
-    "    nr_of_residual_svd_vectors=1,\n",
-    ");"
+    "plot_overview(result.data[\"DPSI590tr4\"], linlog=True, linthresh=150, nr_of_residual_svd_vectors=1)"
    ]
   },
   {
@@ -312,13 +306,7 @@
    },
    "outputs": [],
    "source": [
-    "plot_overview(\n",
-    "    result.data[\"DPSI400tr4\"],\n",
-    "    linlog=True,\n",
-    "    linthresh=150,\n",
-    "    figure_only=False,\n",
-    "    nr_of_residual_svd_vectors=1,\n",
-    ");"
+    "plot_overview(result.data[\"DPSI400tr4\"], linlog=True, linthresh=150, nr_of_residual_svd_vectors=1)"
    ]
   },
   {

--- a/rc/target_rc_part1.ipynb
+++ b/rc/target_rc_part1.ipynb
@@ -220,9 +220,7 @@
    "source": [
     "from pyglotaran_extras import plot_overview\n",
     "\n",
-    "plot_overview(\n",
-    "    initial_result, linlog=True, linthresh=10, figure_only=False, nr_of_residual_svd_vectors=1\n",
-    ");"
+    "plot_overview(initial_result, linlog=True, linthresh=10, nr_of_residual_svd_vectors=1)"
    ]
   },
   {
@@ -571,7 +569,7 @@
    "source": [
     "from pyglotaran_extras import plot_overview\n",
     "\n",
-    "plot_overview(result, linlog=True, linthresh=1, figure_only=False);"
+    "plot_overview(result, linlog=True, linthresh=1);"
    ]
   },
   {

--- a/rc/target_rcg_compare_part2.ipynb
+++ b/rc/target_rcg_compare_part2.ipynb
@@ -360,9 +360,9 @@
    },
    "outputs": [],
    "source": [
-    "# from pyglotaran_extras import plot_overview\n",
+    "from pyglotaran_extras import plot_overview\n",
     "\n",
-    "# plot_overview(result, linlog=True, linthresh=1, figure_only=False);"
+    "plot_overview(result, linlog=True, linthresh=1);"
    ]
   },
   {

--- a/rc/target_rcg_gcrcg_rcgcr_refine_part3.ipynb
+++ b/rc/target_rcg_gcrcg_rcgcr_refine_part3.ipynb
@@ -350,9 +350,9 @@
    },
    "outputs": [],
    "source": [
-    "# from pyglotaran_extras import plot_overview\n",
+    "from pyglotaran_extras import plot_overview\n",
     "\n",
-    "# plot_overview(result, linlog=True, linthresh=1, figure_only=False);"
+    "plot_overview(result, linlog=True, linthresh=1);"
    ]
   },
   {


### PR DESCRIPTION
Since we released `pyglotaran-extras=0.7.0` the argument `figure_only` is deprecated.

[See my fork for test run](https://github.com/s-weigand/pyglotaran-release-paper-supplementary-information/actions/runs/4712335601)