### PR TITLE
🚇 Run CI on push and PR

### DIFF
--- a/.github/workflows/build-pdfs.yml
+++ b/.github/workflows/build-pdfs.yml
@@ -1,9 +1,8 @@
 name: Build-PDFs
 
 on:
-  # For now commented out since private repositories only have a limited amount of CI time
-  # push:
-  # pull_request:
+  push:
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -48,3 +47,9 @@ jobs:
         with:
           name: pdfs
           path: pdfs/*.pdf
+
+      - name: Upload Evaluated Notebooks
+        uses: actions/upload-artifact@v3
+        with:
+          name: notebooks
+          path: ${{ matrix.case_study }}/*.ipynb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,8 @@
 name: Tests
 
 on:
-  # For now commented out since private repositories only have a limited amount of CI time
-  # push:
-  # pull_request:
+  push:
+  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Since the repo is now public we can run the CI on push and PR.
This also allows us to upload PDFs and evaluated notebooks on PRs which simplifies reviewing since they don't need to be evaluated locally.

### Change summary

- [🚇 Run CI on push and PR](https://github.com/glotaran/pyglotaran-release-paper-supplementary-information/commit/ab506e13a6a5e27cac31cf05660b0d9e9ec124e8)

<!-- Documentation changes, only needed if bigger changes were made  -->

<!-- Links to the changed sections

- [section1](link_to_docs_built_for_the_PR)
- [section2](link_to_docs_built_for_the_PR) -->

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)