### PR TITLE
🚇 Upload pdfs and evaluated notebooks as release assets

### DIFF
--- a/.github/workflows/build-pdfs.yml
+++ b/.github/workflows/build-pdfs.yml
@@ -60,3 +60,37 @@ jobs:
         with:
           name: notebooks
           path: ${{ matrix.case_study }}/*.ipynb
+
+  upload-artifacts:
+    name: 📦⬆️ Deploy assets to release page
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    permissions:
+      contents: write
+    needs: build
+    steps:
+      - name: ⬇ Download pdf artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: pdfs
+          path: pdfs
+
+      - name: ⬇ Download notebooks artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: notebooks
+          path: notebooks
+
+      - name: 🚀⬆️ Upload pdf Asset
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: pdfs/*
+
+      - name: 🚀⬆️ Upload notebooks Asset
+        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: notebooks/*
+          generate_release_notes: true
+          append_body: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         additional_dependencies: [black==23.1.0]
         args: [--nbqa-mutate]
       - id: nbqa-pyupgrade
-        additional_dependencies: [pyupgrade==3.3.1]
+        additional_dependencies: [pyupgrade==3.9.0]
         args: [--nbqa-mutate, --py310-plus]
       - id: nbqa-flake8
       - id: nbqa-check-ast


### PR DESCRIPTION
With this change the pdfs and evaluated notebooks are uploaded to the release page when a new release is created.

See [this test release](https://github.com/s-weigand/pyglotaran-release-paper-supplementary-information/releases/tag/asset-upload-on-release-test) on my fork.

### Change summary

- [🚇 Upload pdfs and evaluated notebooks as release assets](https://github.com/glotaran/pyglotaran-release-paper-supplementary-information/commit/65fa5ca5e0733e071c3c118612f1ee87b4db6daf)

### Checklist

- [ ] ✔️ Passing the tests (mandatory for all PR's)